### PR TITLE
Don't cache too much on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,10 +11,9 @@ script:
   - ./gradlew build -x signArchives -s
 
 before_cache:
-  - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock
-  - rm -fr $HOME/.gradle/caches/*/plugin-resolution/
+  - rm -f $HOME/.gradle/caches/modules-2/modules-2.lock
 
 cache:
   directories:
-    - $HOME/.gradle/caches/
-    - $HOME/.gradle/wrapper/
+    - $HOME/.gradle/caches/modules-2/
+    - $HOME/.gradle/wrapper/dists/


### PR DESCRIPTION
Travis is cloning the repository every time so the creation time changes, it make fileHashes to change, and it creates a chain of changes..
Before Gradle 4.10 it worked fine but as I told @oehme now it's not working anymore.

On Travis even if a single file changed the cache will be tar and uploaded, so as the size of the cache grows it can take longer than compile.